### PR TITLE
PanicKit integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,9 @@ apply plugin: 'io.fabric'
 
 dependencies {
     compile 'com.google.code.gson:gson:2.3'
-    compile 'com.android.support:support-v4:22.0.0'
+    compile 'com.android.support:recyclerview-v7:22.2.1'
+    compile 'com.android.support:support-v4:22.2.1'
+    compile 'info.guardianproject.panic:panic:0.3'
     testCompile "org.robolectric:robolectric:3.0"
     testCompile "org.robolectric:shadows-support-v4:3.0"
     testCompile 'junit:junit:4.12'

--- a/app/src/main/assets/mobile_en.json
+++ b/app/src/main/assets/mobile_en.json
@@ -432,6 +432,14 @@
                 "content": "<p>Security Tips</p><ul><li>Think about who can practically assist you  - there is no point someone knowing you are in trouble if they are not in a position to help you</li><li>Make a plan with your chosen contacts so that they are prepared to act fast. </li><li>Be aware of the risks - how might your chosen contact be put at risk? </li></ul>"
             },
             {
+                "id": "settings-panic-responders",
+                "lang": "en",
+                "type": "interactive",
+                "title": "Panic Responders",
+                "introduction": "When you trigger Panic Button, your chosen apps react.  Tap EDIT to see and change that app's behaviors.",
+                "component": "panic-responders"
+            },
+            {
                 "id": "settings-code",
                 "lang": "en",
                 "type": "interactive",
@@ -488,6 +496,10 @@
                     {
                         "title": "Code Settings",
                         "link": "settings-code"
+                    },
+                    {
+                        "title": "Panic Responders",
+                        "link": "settings-panic-responders"
                     },
                     {
                         "title": "Restart the Installation",

--- a/app/src/main/java/org/iilab/pb/MainActivity.java
+++ b/app/src/main/java/org/iilab/pb/MainActivity.java
@@ -18,6 +18,7 @@ import org.iilab.pb.common.ApplicationSettings;
 import org.iilab.pb.data.PBDatabase;
 import org.iilab.pb.fragment.LanguageSettingsFragment;
 import org.iilab.pb.fragment.MainSetupAlertFragment;
+import org.iilab.pb.fragment.PanicRespondersFragment;
 import org.iilab.pb.fragment.SetupCodeFragment;
 import org.iilab.pb.fragment.SetupContactsFragment;
 import org.iilab.pb.fragment.SetupMessageFragment;
@@ -120,6 +121,8 @@ public class MainActivity extends BaseFragmentActivity {
             } else {
                 if (currentPage.getComponent().equals("contacts"))
                     fragment = new SetupContactsFragment().newInstance(pageId, AppConstants.FROM_MAIN_ACTIVITY);
+                else if (currentPage.getComponent().equals("panic-responders"))
+                    fragment = new PanicRespondersFragment().newInstance(pageId, AppConstants.FROM_MAIN_ACTIVITY);
                 else if (currentPage.getComponent().equals("message"))
                     fragment = new SetupMessageFragment().newInstance(pageId, AppConstants.FROM_MAIN_ACTIVITY);
                 else if (currentPage.getComponent().equals("code"))

--- a/app/src/main/java/org/iilab/pb/WizardActivity.java
+++ b/app/src/main/java/org/iilab/pb/WizardActivity.java
@@ -21,6 +21,7 @@ import org.iilab.pb.common.ApplicationSettings;
 import org.iilab.pb.common.MyTagHandler;
 import org.iilab.pb.data.PBDatabase;
 import org.iilab.pb.fragment.LanguageSettingsFragment;
+import org.iilab.pb.fragment.PanicRespondersFragment;
 import org.iilab.pb.fragment.SetupCodeFragment;
 import org.iilab.pb.fragment.SetupContactsFragment;
 import org.iilab.pb.fragment.SetupMessageFragment;
@@ -130,6 +131,8 @@ public class WizardActivity extends BaseFragmentActivity {
             } else {          // type = interactive
                 if (currentPage.getComponent().equals("contacts"))
                     fragment = new SetupContactsFragment().newInstance(pageId, FROM_WIZARD_ACTIVITY);
+                else if (currentPage.getComponent().equals("panic-responders"))
+                    fragment = new PanicRespondersFragment().newInstance(pageId, FROM_WIZARD_ACTIVITY);
                 else if (currentPage.getComponent().equals("message"))
                     fragment = new SetupMessageFragment().newInstance(pageId, FROM_WIZARD_ACTIVITY);
                 else if (currentPage.getComponent().equals("code"))

--- a/app/src/main/java/org/iilab/pb/alert/PanicAlert.java
+++ b/app/src/main/java/org/iilab/pb/alert/PanicAlert.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import info.guardianproject.panic.PanicTrigger;
+
 import static android.location.LocationManager.GPS_PROVIDER;
 import static android.location.LocationManager.NETWORK_PROVIDER;
 import static org.iilab.pb.common.Intents.locationPendingIntent;
@@ -67,6 +69,8 @@ public class PanicAlert {
 
     private void activateAlert() {
         ApplicationSettings.setAlertActive(context, true);
+        // send panic triggers to responder apps that support it
+        PanicTrigger.sendTrigger(context);
         sendFirstAlert();
         registerLocationUpdate();
         scheduleFutureAlert();

--- a/app/src/main/java/org/iilab/pb/fragment/PanicRespondersFragment.java
+++ b/app/src/main/java/org/iilab/pb/fragment/PanicRespondersFragment.java
@@ -1,13 +1,26 @@
 package org.iilab.pb.fragment;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.graphics.ColorMatrix;
+import android.graphics.ColorMatrixColorFilter;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CompoundButton;
+import android.widget.ImageView;
+import android.widget.Switch;
 import android.widget.TextView;
 
 import org.iilab.pb.R;
@@ -16,9 +29,15 @@ import org.iilab.pb.common.ApplicationSettings;
 import org.iilab.pb.data.PBDatabase;
 import org.iilab.pb.model.Page;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+
+import info.guardianproject.panic.PanicTrigger;
 
 public class PanicRespondersFragment extends Fragment {
+    public static final String TAG = "PanicRespondersFragment";
 
     private static final String PAGE_ID = "page_id";
     private static final String PARENT_ACTIVITY = "parent_activity";
@@ -27,6 +46,19 @@ public class PanicRespondersFragment extends Fragment {
     TextView tvTitle, tvIntro;
     Page currentPage;
     PageItemAdapter pageItemAdapter;
+
+    private static final int CONNECT_RESULT = 0x01;
+
+    private String responders[];
+    private Set<String> enabledResponders;
+    private Set<String> respondersThatCanConnect;
+    private ArrayList<CharSequence> appLabelList;
+    private ArrayList<Drawable> iconList;
+
+    private SharedPreferences prefs;
+
+    private String requestPackageName;
+    private String requestAction;
 
     public static PanicRespondersFragment newInstance(String pageId, int parentActivity) {
         PanicRespondersFragment f = new PanicRespondersFragment();
@@ -45,6 +77,63 @@ public class PanicRespondersFragment extends Fragment {
         tvIntro = (TextView) view.findViewById(R.id.fragment_intro);
 
         return view;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        enabledResponders = PanicTrigger.getEnabledResponders(activity);
+        respondersThatCanConnect = PanicTrigger.getRespondersThatCanConnect(activity);
+
+        // sort enabled first, then disabled
+        LinkedHashSet<String> a = new LinkedHashSet<String>(enabledResponders);
+        LinkedHashSet<String> b = new LinkedHashSet(PanicTrigger.getAllResponders(activity));
+        b.removeAll(enabledResponders);
+        a.addAll(b);
+        responders = a.toArray(new String[a.size()]);
+
+        PackageManager pm = getActivity().getPackageManager();
+        appLabelList = new ArrayList<CharSequence>(responders.length);
+        iconList = new ArrayList<Drawable>(responders.length);
+        for (String packageName : responders) {
+            try {
+                appLabelList.add(pm.getApplicationLabel(pm.getApplicationInfo(packageName, 0)));
+                iconList.add(pm.getApplicationIcon(packageName));
+            } catch (PackageManager.NameNotFoundException e) {
+                e.printStackTrace();
+            }
+        }
+
+        RecyclerView recyclerView = (RecyclerView) activity.findViewById(R.id.recycler_view);
+        recyclerView.addItemDecoration(new SimpleDividerItemDecoration(activity));
+        recyclerView.setHasFixedSize(true); // does not change, except in onResume()
+        recyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        recyclerView.setAdapter(new RecyclerView.Adapter<AppRowHolder>() {
+            @Override
+            public AppRowHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+                Context context = parent.getContext();
+                LayoutInflater layoutInflater = LayoutInflater.from(context);
+                View view = layoutInflater.inflate(R.layout.responder_row, parent, false);
+                return new AppRowHolder(view);
+            }
+
+            @Override
+            public void onBindViewHolder(AppRowHolder holder, int position) {
+                String packageName = responders[position];
+                boolean canConnect = respondersThatCanConnect.contains(packageName);
+                holder.setupForApp(
+                        packageName,
+                        iconList.get(position),
+                        appLabelList.get(position),
+                        canConnect);
+            }
+
+            @Override
+            public int getItemCount() {
+                return appLabelList.size();
+            }
+        });
     }
 
     @Override
@@ -84,6 +173,91 @@ public class PanicRespondersFragment extends Fragment {
             for (Fragment fragment : fragments) {
                 fragment.onActivityResult(requestCode, resultCode, intent);
             }
+        }
+    }
+
+
+    class AppRowHolder extends RecyclerView.ViewHolder {
+
+        private final View.OnClickListener onClickListener;
+        private final Switch onSwitch;
+        private final TextView editableLabel;
+        private final ImageView iconView;
+        private final TextView appLabelView;
+        private String rowPackageName;
+
+        AppRowHolder(final View row) {
+            super(row);
+
+            iconView = (ImageView) row.findViewById(R.id.iconView);
+            appLabelView = (TextView) row.findViewById(R.id.appLabel);
+            editableLabel = (TextView) row.findViewById(R.id.editableLabel);
+            onSwitch = (Switch) row.findViewById(R.id.on_switch);
+            onClickListener = new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    requestPackageName = rowPackageName;
+                    Intent intent = new Intent(requestAction);
+                    intent.setPackage(requestPackageName);
+                    startActivityForResult(intent, CONNECT_RESULT);
+                }
+            };
+
+            onSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton, boolean enabled) {
+                    setEnabled(enabled);
+                    if (enabled) {
+                        PanicTrigger.enableResponder(activity, rowPackageName);
+                    } else {
+                        PanicTrigger.disableResponder(activity, rowPackageName);
+                    }
+                }
+            });
+        }
+
+        void setEnabled(boolean enabled) {
+            if (enabled) {
+                editableLabel.setVisibility(View.VISIBLE);
+                appLabelView.setEnabled(true);
+                iconView.setEnabled(true);
+                iconView.setColorFilter(null);
+            } else {
+                editableLabel.setVisibility(View.GONE);
+                appLabelView.setEnabled(false);
+                iconView.setEnabled(false);
+                // grey out app icon when disabled
+                ColorMatrix matrix = new ColorMatrix();
+                matrix.setSaturation(0);
+                ColorMatrixColorFilter filter = new ColorMatrixColorFilter(matrix);
+                iconView.setColorFilter(filter);
+            }
+        }
+
+        void setupForApp(String packageName, Drawable icon, CharSequence appLabel, boolean editable) {
+            this.rowPackageName = packageName;
+            iconView.setImageDrawable(icon);
+            appLabelView.setText(appLabel);
+            if (editable) {
+                iconView.setOnClickListener(onClickListener);
+                appLabelView.setOnClickListener(onClickListener);
+                editableLabel.setOnClickListener(onClickListener);
+                editableLabel.setText(R.string.edit);
+                editableLabel.setTypeface(null, Typeface.BOLD);
+                if (Build.VERSION.SDK_INT >= 14)
+                    editableLabel.setAllCaps(true);
+            } else {
+                iconView.setOnClickListener(null);
+                appLabelView.setOnClickListener(null);
+                editableLabel.setOnClickListener(null);
+                editableLabel.setText(R.string.app_hides);
+                editableLabel.setTypeface(null, Typeface.NORMAL);
+                if (Build.VERSION.SDK_INT >= 14)
+                    editableLabel.setAllCaps(false);
+            }
+            boolean enabled = enabledResponders.contains(packageName);
+            onSwitch.setChecked(enabled);
+            setEnabled(enabled);
         }
     }
 

--- a/app/src/main/java/org/iilab/pb/fragment/PanicRespondersFragment.java
+++ b/app/src/main/java/org/iilab/pb/fragment/PanicRespondersFragment.java
@@ -1,0 +1,90 @@
+package org.iilab.pb.fragment;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.util.DisplayMetrics;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import org.iilab.pb.R;
+import org.iilab.pb.adapter.PageItemAdapter;
+import org.iilab.pb.common.ApplicationSettings;
+import org.iilab.pb.data.PBDatabase;
+import org.iilab.pb.model.Page;
+
+import java.util.List;
+
+public class PanicRespondersFragment extends Fragment {
+
+    private static final String PAGE_ID = "page_id";
+    private static final String PARENT_ACTIVITY = "parent_activity";
+    private Activity activity;
+    DisplayMetrics metrics;
+    TextView tvTitle, tvIntro;
+    Page currentPage;
+    PageItemAdapter pageItemAdapter;
+
+    public static PanicRespondersFragment newInstance(String pageId, int parentActivity) {
+        PanicRespondersFragment f = new PanicRespondersFragment();
+        Bundle args = new Bundle();
+        args.putString(PAGE_ID, pageId);
+        args.putInt(PARENT_ACTIVITY, parentActivity);
+        f.setArguments(args);
+        return (f);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_type_interactive_panic_responders, container, false);
+
+        tvTitle = (TextView) view.findViewById(R.id.fragment_title);
+        tvIntro = (TextView) view.findViewById(R.id.fragment_intro);
+
+        return view;
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        activity = getActivity();
+        if (activity != null) {
+            metrics = new DisplayMetrics();
+            activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+            String pageId = getArguments().getString(PAGE_ID);
+            String selectedLang = ApplicationSettings.getSelectedLanguage(activity);
+
+            PBDatabase dbInstance = new PBDatabase(activity);
+            dbInstance.open();
+            currentPage = dbInstance.retrievePage(pageId, selectedLang);
+            dbInstance.close();
+
+            tvTitle.setText(currentPage.getTitle());
+
+            if (currentPage.getIntroduction() == null) {
+                tvIntro.setVisibility(View.GONE);
+            } else {
+                tvIntro.setText(currentPage.getIntroduction());
+            }
+
+            pageItemAdapter = new PageItemAdapter(activity, null);
+            pageItemAdapter.setData(currentPage.getItems());
+        }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        super.onActivityResult(requestCode, resultCode, intent);
+        List<Fragment> fragments = getChildFragmentManager().getFragments();
+        if (fragments != null) {
+            for (Fragment fragment : fragments) {
+                fragment.onActivityResult(requestCode, resultCode, intent);
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/org/iilab/pb/fragment/SimpleDividerItemDecoration.java
+++ b/app/src/main/java/org/iilab/pb/fragment/SimpleDividerItemDecoration.java
@@ -1,0 +1,36 @@
+package org.iilab.pb.fragment;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import org.iilab.pb.R;
+
+public class SimpleDividerItemDecoration extends RecyclerView.ItemDecoration {
+    private final Drawable mDivider;
+
+    public SimpleDividerItemDecoration(Context context) {
+        mDivider = context.getResources().getDrawable(R.drawable.responder_line_divider);
+    }
+
+    @Override
+    public void onDrawOver(Canvas c, RecyclerView parent, RecyclerView.State state) {
+        int left = parent.getPaddingLeft();
+        int right = parent.getWidth() - parent.getPaddingRight();
+
+        int childCount = parent.getChildCount();
+        for (int i = 0; i < childCount; i++) {
+            View child = parent.getChildAt(i);
+
+            RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) child.getLayoutParams();
+
+            int top = child.getBottom() + params.bottomMargin;
+            int bottom = top + mDivider.getIntrinsicHeight();
+
+            mDivider.setBounds(left, top, right, bottom);
+            mDivider.draw(c);
+        }
+    }
+}

--- a/app/src/main/res/drawable/responder_line_divider.xml
+++ b/app/src/main/res/drawable/responder_line_divider.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <size
+        android:width="1dp"
+        android:height="1dp" />
+
+    <solid android:color="@color/gray" />
+
+</shape>

--- a/app/src/main/res/layout/fragment_type_interactive_panic_responders.xml
+++ b/app/src/main/res/layout/fragment_type_interactive_panic_responders.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical"
+    android:descendantFocusability="beforeDescendants"
+    android:focusableInTouchMode="true">
+
+    <ScrollView
+        android:id="@+id/wizard_start_root"
+        android:layout_height="wrap_content"
+        android:layout_width="fill_parent">
+
+        <RelativeLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            style="@style/wizard_static_panel">
+
+            <TextView
+                android:id="@+id/fragment_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/page_title_text"
+                android:textSize="32sp"
+                android:paddingBottom="5dp"
+                android:layout_centerHorizontal="true" />
+
+            <TextView
+                android:id="@+id/fragment_intro"
+                style="@style/wizard_intro_style"
+                android:layout_below="@+id/fragment_title" />
+
+        </RelativeLayout>
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_type_interactive_panic_responders.xml
+++ b/app/src/main/res/layout/fragment_type_interactive_panic_responders.xml
@@ -1,36 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:orientation="vertical"
-    android:descendantFocusability="beforeDescendants"
-    android:focusableInTouchMode="true">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <ScrollView
-        android:id="@+id/wizard_start_root"
+    <LinearLayout
+        style="@style/wizard_static_panel"
+        android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_width="fill_parent">
+        android:orientation="vertical">
 
-        <RelativeLayout
-            android:layout_width="fill_parent"
+        <TextView
+            android:id="@+id/fragment_title"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            style="@style/wizard_static_panel">
+            android:gravity="center_horizontal"
+            android:paddingBottom="5dp"
+            android:text="@string/page_title_text"
+            android:textSize="32sp" />
 
-            <TextView
-                android:id="@+id/fragment_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/page_title_text"
-                android:textSize="32sp"
-                android:paddingBottom="5dp"
-                android:layout_centerHorizontal="true" />
+        <TextView
+            android:id="@+id/fragment_intro"
+            style="@style/wizard_intro_style"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
-            <TextView
-                android:id="@+id/fragment_intro"
-                style="@style/wizard_intro_style"
-                android:layout_below="@+id/fragment_title" />
+    </LinearLayout>
 
-        </RelativeLayout>
-    </ScrollView>
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/responder_row.xml
+++ b/app/src/main/res/layout/responder_row.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/iconView"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:gravity="center"
+        android:padding="20dp"
+        android:src="@android:drawable/ic_dialog_alert"/>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_centerVertical="true"
+        android:layout_toEndOf="@+id/iconView"
+        android:layout_toLeftOf="@+id/on_switch"
+        android:layout_toRightOf="@+id/iconView"
+        android:layout_toStartOf="@+id/on_switch"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/appLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="5dp"
+            android:textAppearance="?android:attr/textAppearanceLarge" />
+
+        <TextView
+            android:id="@+id/editableLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/app_hides"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="@android:color/darker_gray" />
+    </LinearLayout>
+
+    <Switch
+        android:id="@+id/on_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        android:padding="20dp" />
+
+</RelativeLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="active_color">#fc2d2d</color>
     <color name="yellow">#fcc542</color>
     <color name="standby_color">#ff0000ff</color>
+    <color name="gray">#ffdddddd</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,4 +66,7 @@
     <string name="deactivate_power_button_trigger">Deactivated</string>
     <string name="activate_power_button_trigger">Activated </string>
     <string name="debug_mode">Debug Mode </string>
+
+    <string name="edit">Edit</string>
+    <string name="app_hides">App hides when triggered</string>
 </resources>


### PR DESCRIPTION
This adds a settings screen called "Panic Responders" that lets the user configure which apps will receive the PanicKit panic trigger when the panic button is pressed.  This also hooks up the panic button to send the PanicKit trigger message to all enabled apps.

You can see an example of this setup here:
https://www.youtube.com/watch?v=mS1gstS6YS8

It is demoing [Ripple](https://github.com/guardianproject/ripple), [Orweb](https://github.com/guardianproject/orweb), and a little bit of [Zom](https://github.com/zom/zom-android).
